### PR TITLE
feat: implementação completa do CRUD de vendas (Sales)

### DIFF
--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleCommand.cs
@@ -1,0 +1,24 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale
+{
+    public class CreateSaleCommand : IRequest<CreateSaleResult>
+    {
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public Guid CustomerId { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public List<CreateSaleItemDto> Items { get; set; }
+    }
+
+    public class CreateSaleItemDto
+    {
+        public Guid ProductId { get; set; }
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleHandler.cs
@@ -1,0 +1,61 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using MediatR;
+using System;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale
+{
+
+    public class CreateSaleHandler : IRequestHandler<CreateSaleCommand, CreateSaleResult>
+    {
+        private readonly ISaleRepository _saleRepository;
+        private readonly IMapper _mapper;
+
+        public CreateSaleHandler(ISaleRepository saleRepository, IMapper mapper)
+        {
+            _saleRepository = saleRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<CreateSaleResult> Handle(CreateSaleCommand request, CancellationToken cancellationToken)
+        {
+            var sale = _mapper.Map<Sale>(request);
+            sale.Id = Guid.NewGuid();
+            sale.IsCancelled = false;
+
+            foreach (var item in sale.Items)
+            {
+                item.Id = Guid.NewGuid();
+                item.DiscountPercentage = CalculateDiscount(item.Quantity);
+                item.TotalItemAmount = CalculateTotalItem(item.Quantity, item.UnitPrice, item.DiscountPercentage);
+                item.IsCancelled = false;
+            }
+
+            sale.TotalAmount = sale.Items.Sum(i => i.TotalItemAmount);
+
+            await _saleRepository.AddAsync(sale);
+
+            return new CreateSaleResult
+            {
+                Id = sale.Id,
+                SaleNumber = sale.SaleNumber,
+                TotalAmount = sale.TotalAmount,
+                CreatedAt = DateTime.UtcNow
+            };
+        }
+
+        private decimal CalculateDiscount(int quantity)
+        {
+            if (quantity >= 10 && quantity <= 20) return 20;
+            if (quantity >= 4 && quantity < 10) return 10;
+            return 0;
+        }
+
+        private decimal CalculateTotalItem(int quantity, decimal unitPrice, decimal discount)
+        {
+            var total = quantity * unitPrice;
+            return total - (total * discount / 100);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleProfile.cs
@@ -1,0 +1,14 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale
+{
+    public class CreateSaleProfile : Profile
+    {
+        public CreateSaleProfile()
+        {
+            CreateMap<CreateSaleCommand, Sale>();
+            CreateMap<CreateSaleItemDto, SaleItem>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleResult.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale
+{
+    public class CreateSaleResult
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public decimal TotalAmount { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleValidator.cs
@@ -1,0 +1,28 @@
+﻿using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale
+{
+    public class CreateSaleValidator : AbstractValidator<CreateSaleCommand>
+    {
+        public CreateSaleValidator()
+        {
+            RuleFor(s => s.SaleNumber).GreaterThan(0);
+            RuleFor(s => s.CustomerId).NotEmpty();
+            RuleFor(s => s.CustomerName).NotEmpty().MaximumLength(100);
+            RuleFor(s => s.Branch).NotEmpty().MaximumLength(50);
+
+            RuleForEach(s => s.Items).SetValidator(new CreateSaleItemValidator());
+        }
+    }
+
+    public class CreateSaleItemValidator : AbstractValidator<CreateSaleItemDto>
+    {
+        public CreateSaleItemValidator()
+        {
+            RuleFor(i => i.ProductId).NotEmpty();
+            RuleFor(i => i.ProductName).NotEmpty().MaximumLength(100);
+            RuleFor(i => i.Quantity).InclusiveBetween(1, 20);
+            RuleFor(i => i.UnitPrice).GreaterThan(0);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleCommand.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using System;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.DeleteSale
+{
+    public class DeleteSaleCommand : IRequest<bool>
+    {
+        public Guid Id { get; set; }
+
+        public DeleteSaleCommand(Guid id)
+        {
+            Id = id;
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/DeleteSale/DeleteSaleHandler.cs
@@ -1,0 +1,28 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Repositories;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.DeleteSale
+{
+    public class DeleteSaleHandler : IRequestHandler<DeleteSaleCommand, bool>
+    {
+        private readonly ISaleRepository _saleRepository;
+
+        public DeleteSaleHandler(ISaleRepository saleRepository)
+        {
+            _saleRepository = saleRepository;
+        }
+
+        public async Task<bool> Handle(DeleteSaleCommand request, CancellationToken cancellationToken)
+        {
+            var existingSale = await _saleRepository.GetByIdAsync(request.Id);
+
+            if (existingSale == null)
+                return false;
+
+            await _saleRepository.DeleteAsync(request.Id);
+            return true;
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleHandler.cs
@@ -1,0 +1,27 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSale
+{
+
+    public class GetSaleHandler : IRequestHandler<GetSaleQuery, GetSaleResult>
+    {
+        private readonly ISaleRepository _saleRepository;
+        private readonly IMapper _mapper;
+
+        public GetSaleHandler(ISaleRepository saleRepository, IMapper mapper)
+        {
+            _saleRepository = saleRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<GetSaleResult> Handle(GetSaleQuery request, CancellationToken cancellationToken)
+        {
+            var sale = await _saleRepository.GetByIdAsync(request.Id);
+            return _mapper.Map<GetSaleResult>(sale);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleProfile.cs
@@ -1,0 +1,14 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSale
+{
+    public class GetSaleProfile : Profile
+    {
+        public GetSaleProfile()
+        {
+            CreateMap<Sale, GetSaleResult>();
+            CreateMap<SaleItem, GetSaleItemDto>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleQuery.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleQuery.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+using System;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSale
+{
+    public class GetSaleQuery : IRequest<GetSaleResult>
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleResult.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSale
+{
+    public class GetSaleResult
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public decimal TotalAmount { get; set; }
+        public bool IsCancelled { get; set; }
+        public List<GetSaleItemDto> Items { get; set; }
+    }
+
+    public class GetSaleItemDto
+    {
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+        public decimal TotalItemAmount { get; set; }
+        public bool IsCancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSale
+{
+    public class GetSaleValidator : AbstractValidator<GetSaleQuery>
+    {
+        public GetSaleValidator()
+        {
+            RuleFor(x => x.Id).NotEmpty().WithMessage("Sale ID must be provided.");
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesHandler.cs
@@ -1,0 +1,38 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using MediatR;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSales
+{
+    public class GetSalesHandler : IRequestHandler<GetSalesQuery, GetSalesResult>
+    {
+        private readonly ISaleRepository _saleRepository;
+        private readonly IMapper _mapper;
+
+        public GetSalesHandler(ISaleRepository saleRepository, IMapper mapper)
+        {
+            _saleRepository = saleRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<GetSalesResult> Handle(GetSalesQuery request, CancellationToken cancellationToken)
+        {
+            var (sales, totalItems) = await _saleRepository.GetSalesPagedAsync(
+                request.Page, request.Size, request.Order, request.Branch, request.MinDate, request.MaxDate
+            );
+
+            var result = new GetSalesResult
+            {
+                Data = _mapper.Map<IEnumerable<SaleListItemDto>>(sales),
+                TotalItems = totalItems,
+                CurrentPage = request.Page,
+                TotalPages = (int)System.Math.Ceiling(totalItems / (double)request.Size)
+            };
+
+            return result;
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesProfile.cs
@@ -1,0 +1,14 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.GetSales;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSales
+{
+    public class GetSalesProfile : Profile
+    {
+        public GetSalesProfile()
+        {
+            CreateMap<Sale, SaleListItemDto>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesQuery.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesQuery.cs
@@ -1,0 +1,17 @@
+﻿using MediatR;
+using System;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSales
+{
+    public class GetSalesQuery : IRequest<GetSalesResult>
+    {
+        public int Page { get; set; } = 1;
+        public int Size { get; set; } = 10;
+        public string Order { get; set; } = "SaleDate desc";
+
+        // Filtros opcionais
+        public string Branch { get; set; }
+        public DateTime? MinDate { get; set; }
+        public DateTime? MaxDate { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesResult.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSales
+{
+    public class GetSalesResult
+    {
+        public IEnumerable<SaleListItemDto> Data { get; set; }
+        public int TotalItems { get; set; }
+        public int CurrentPage { get; set; }
+        public int TotalPages { get; set; }
+    }
+
+    public class SaleListItemDto
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public decimal TotalAmount { get; set; }
+        public bool IsCancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSales/GetSalesValidator.cs
@@ -1,0 +1,63 @@
+﻿using FluentValidation;
+using System;
+using System.Linq;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.GetSales
+{
+    public class GetSalesValidator : AbstractValidator<GetSalesQuery>
+    {
+        private static readonly string[] AllowedOrderFields =
+        {
+        "SaleNumber", "SaleDate", "CustomerName", "Branch", "TotalAmount"
+    };
+
+        public GetSalesValidator()
+        {
+            RuleFor(x => x.Page)
+                .GreaterThan(0)
+                .WithMessage("Page must be greater than 0.");
+
+            RuleFor(x => x.Size)
+                .InclusiveBetween(1, 100)
+                .WithMessage("Size must be between 1 and 100.");
+
+            RuleFor(x => x.Order)
+                .Must(BeValidOrder)
+                .WithMessage("Order must contain valid fields and directions (asc, desc).");
+
+            RuleFor(x => x.MinDate)
+                .LessThanOrEqualTo(DateTime.UtcNow)
+                .When(x => x.MinDate.HasValue)
+                .WithMessage("MinDate cannot be in the future.");
+
+            RuleFor(x => x.MaxDate)
+                .LessThanOrEqualTo(DateTime.UtcNow)
+                .When(x => x.MaxDate.HasValue)
+                .WithMessage("MaxDate cannot be in the future.");
+        }
+
+        private bool BeValidOrder(string order)
+        {
+            if (string.IsNullOrWhiteSpace(order))
+                return true;
+
+            var orderParts = order.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var part in orderParts)
+            {
+                var trimmed = part.Trim();
+                var tokens = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                if (tokens.Length == 0 || tokens.Length > 2)
+                    return false;
+
+                var field = tokens[0];
+                var direction = tokens.Length == 2 ? tokens[1].ToLower() : "asc";
+
+                if (!AllowedOrderFields.Contains(field) || (direction != "asc" && direction != "desc"))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleCommand.cs
@@ -1,0 +1,25 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.UpdateSale
+{
+    public class UpdateSaleCommand : IRequest<UpdateSaleResult>
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public Guid CustomerId { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public List<UpdateSaleItemDto> Items { get; set; } = [];
+    }
+
+    public class UpdateSaleItemDto
+    {
+        public Guid ProductId { get; set; }
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleHandler.cs
@@ -1,0 +1,75 @@
+﻿using Ambev.DeveloperEvaluation.Common.Exceptions;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using MediatR;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.UpdateSale
+{
+    public class UpdateSaleHandler : IRequestHandler<UpdateSaleCommand, UpdateSaleResult>
+    {
+        private readonly ISaleRepository _saleRepository;
+        private readonly IMapper _mapper;
+
+        public UpdateSaleHandler(ISaleRepository saleRepository, IMapper mapper)
+        {
+            _saleRepository = saleRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<UpdateSaleResult> Handle(UpdateSaleCommand request, CancellationToken cancellationToken)
+        {
+            var sale = await _saleRepository.GetByIdAsync(request.Id);
+
+            if (sale == null)
+                return null;
+
+            sale.SaleNumber = request.SaleNumber;
+            sale.SaleDate = request.SaleDate;
+            sale.CustomerId = request.CustomerId;
+            sale.CustomerName = request.CustomerName;
+            sale.Branch = request.Branch;
+
+            sale.Items = new List<SaleItem>();
+
+            foreach (var item in request.Items)
+            {
+                var saleItem = new SaleItem
+                {
+                    Id = Guid.NewGuid(),
+                    SaleId = sale.Id,
+                    ProductId = item.ProductId,
+                    ProductName = item.ProductName,
+                    Quantity = item.Quantity,
+                    UnitPrice = item.UnitPrice,
+                    TotalItemAmount = CalculateDiscountedAmount(item.Quantity, item.UnitPrice),
+                    IsCancelled = false
+                };
+
+                sale.Items.Add(saleItem);
+            }
+
+            sale.TotalAmount = sale.Items.Sum(i => i.TotalItemAmount);
+
+            await _saleRepository.UpdateAsync(sale);
+
+            return _mapper.Map<UpdateSaleResult>(sale);
+        }
+
+        private decimal CalculateDiscountedAmount(int quantity, decimal unitPrice)
+        {
+            decimal discount = 0;
+
+            if (quantity >= 10 && quantity <= 20)
+                discount = 0.20m;
+            else if (quantity >= 4 && quantity < 10)
+                discount = 0.10m;
+
+            if (quantity > 20)
+                throw new BusinessException("Cannot sell more than 20 identical items per product.");
+
+            var total = quantity * unitPrice;
+            return total - (total * discount);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleProfile.cs
@@ -1,0 +1,13 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.UpdateSale
+{
+    public class UpdateSaleProfile : Profile
+    {
+        public UpdateSaleProfile()
+        {
+            CreateMap<Sale, UpdateSaleResult>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleResult.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.UpdateSale
+{
+    public class UpdateSaleResult
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public decimal TotalAmount { get; set; }
+        public bool IsCancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Common/Exceptions/BusinessException.cs
+++ b/src/Ambev.DeveloperEvaluation.Common/Exceptions/BusinessException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.Common.Exceptions
+{
+    public class BusinessException : Exception
+    {
+        public BusinessException(string message) : base(message) { }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Domain/Ambev.DeveloperEvaluation.Domain.csproj
+++ b/src/Ambev.DeveloperEvaluation.Domain/Ambev.DeveloperEvaluation.Domain.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <Folder Include="Enums\" />
     <Folder Include="Exceptions\" />
-    <Folder Include="Repositories\" />
     <Folder Include="Events\" />
     <Folder Include="ValueObjects\" />
   </ItemGroup>

--- a/src/Ambev.DeveloperEvaluation.Domain/Entities/Sale.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Entities/Sale.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.Domain.Entities;
+
+public class Sale
+{
+    public Guid Id { get; set; }
+    public int SaleNumber { get; set; }
+    public DateTime SaleDate { get; set; }
+    public Guid CustomerId { get; set; }
+    public string CustomerName { get; set; }
+    public decimal TotalAmount { get; set; }
+    public string Branch { get; set; }
+    public bool IsCancelled { get; set; }
+
+    public List<SaleItem> Items { get; set; } = new();
+}
+
+public class SaleItem
+{
+    public Guid Id { get; set; }
+    public Guid SaleId { get; set; }
+    public Guid ProductId { get; set; }
+    public string ProductName { get; set; }
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+    public decimal DiscountPercentage { get; set; }
+    public decimal TotalItemAmount { get; set; }
+    public bool IsCancelled { get; set; }
+}

--- a/src/Ambev.DeveloperEvaluation.Domain/Repositories/ISaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Repositories/ISaleRepository.cs
@@ -1,0 +1,18 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ambev.DeveloperEvaluation.Domain.Repositories
+{
+    public interface ISaleRepository
+    {
+        Task<IEnumerable<Sale>> GetAllAsync();
+        Task<Sale> GetByIdAsync(Guid id);
+        Task AddAsync(Sale sale);
+        Task UpdateAsync(Sale sale);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Domain/Repositories/ISaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Repositories/ISaleRepository.cs
@@ -14,5 +14,7 @@ namespace Ambev.DeveloperEvaluation.Domain.Repositories
         Task AddAsync(Sale sale);
         Task UpdateAsync(Sale sale);
         Task DeleteAsync(Guid id);
+        Task<(List<Sale> Sales, int TotalItems)> GetSalesPagedAsync(
+            int page, int size, string order, string branch, DateTime? minDate, DateTime? maxDate);
     }
 }

--- a/src/Ambev.DeveloperEvaluation.IoC/ModuleInitializers/InfrastructureModuleInitializer.cs
+++ b/src/Ambev.DeveloperEvaluation.IoC/ModuleInitializers/InfrastructureModuleInitializer.cs
@@ -13,6 +13,9 @@ public class InfrastructureModuleInitializer : IModuleInitializer
     public void Initialize(WebApplicationBuilder builder)
     {
         builder.Services.AddScoped<DbContext>(provider => provider.GetRequiredService<DefaultContext>());
+        
         builder.Services.AddScoped<IUserRepository, UserRepository>();
+
+        builder.Services.AddScoped<ISaleRepository, SaleRepository>();
     }
 }

--- a/src/Ambev.DeveloperEvaluation.ORM/Ambev.DeveloperEvaluation.ORM.csproj
+++ b/src/Ambev.DeveloperEvaluation.ORM/Ambev.DeveloperEvaluation.ORM.csproj
@@ -17,6 +17,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+		<PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Ambev.DeveloperEvaluation.Domain\Ambev.DeveloperEvaluation.Domain.csproj" />

--- a/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
@@ -9,6 +9,8 @@ namespace Ambev.DeveloperEvaluation.ORM;
 public class DefaultContext : DbContext
 {
     public DbSet<User> Users { get; set; }
+    public DbSet<Sale> Sales { get; set; }
+    public DbSet<SaleItem> SaleItems { get; set; }
 
     public DefaultContext(DbContextOptions<DefaultContext> options) : base(options)
     {

--- a/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
@@ -1,0 +1,76 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ambev.DeveloperEvaluation.ORM.Mapping
+{
+    public class SaleConfiguration : IEntityTypeConfiguration<Sale>
+    {
+        public void Configure(EntityTypeBuilder<Sale> builder)
+        {
+            builder.HasKey(s => s.Id);
+
+            builder.Property(s => s.SaleNumber)
+                .IsRequired();
+
+            builder.Property(s => s.SaleDate)
+                .IsRequired();
+
+            builder.Property(s => s.CustomerId)
+                .IsRequired();
+
+            builder.Property(s => s.CustomerName)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            builder.Property(s => s.TotalAmount)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            builder.Property(s => s.Branch)
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(s => s.IsCancelled)
+                .IsRequired();
+
+            builder.HasMany(s => s.Items)
+                .WithOne()
+                .HasForeignKey(i => i.SaleId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+
+    public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
+    {
+        public void Configure(EntityTypeBuilder<SaleItem> builder)
+        {
+            builder.HasKey(si => si.Id);
+
+            builder.Property(si => si.ProductId)
+                .IsRequired();
+
+            builder.Property(si => si.ProductName)
+                .IsRequired()
+                .HasMaxLength(100);
+
+            builder.Property(si => si.Quantity)
+                .IsRequired();
+
+            builder.Property(si => si.UnitPrice)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            builder.Property(si => si.DiscountPercentage)
+                .HasColumnType("decimal(5,2)")
+                .IsRequired();
+
+            builder.Property(si => si.TotalItemAmount)
+                .HasColumnType("decimal(18,2)")
+                .IsRequired();
+
+            builder.Property(si => si.IsCancelled)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250321141058_AddSalesEntities.Designer.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250321141058_AddSalesEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Ambev.DeveloperEvaluation.ORM;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Ambev.DeveloperEvaluation.ORM.Migrations
 {
     [DbContext(typeof(DefaultContext))]
-    partial class DefaultContextModelSnapshot : ModelSnapshot
+    [Migration("20250321141058_AddSalesEntities")]
+    partial class AddSalesEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250321141058_AddSalesEntities.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250321141058_AddSalesEntities.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ambev.DeveloperEvaluation.ORM.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSalesEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Sales",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SaleNumber = table.Column<int>(type: "integer", nullable: false),
+                    SaleDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CustomerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CustomerName = table.Column<string>(type: "text", nullable: false),
+                    TotalAmount = table.Column<decimal>(type: "numeric", nullable: false),
+                    Branch = table.Column<string>(type: "text", nullable: false),
+                    IsCancelled = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sales", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SaleItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SaleId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProductName = table.Column<string>(type: "text", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false),
+                    UnitPrice = table.Column<decimal>(type: "numeric", nullable: false),
+                    DiscountPercentage = table.Column<decimal>(type: "numeric", nullable: false),
+                    TotalItemAmount = table.Column<decimal>(type: "numeric", nullable: false),
+                    IsCancelled = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SaleItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SaleItems_Sales_SaleId",
+                        column: x => x.SaleId,
+                        principalTable: "Sales",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SaleItems_SaleId",
+                table: "SaleItems",
+                column: "SaleId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SaleItems");
+
+            migrationBuilder.DropTable(
+                name: "Sales");
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
@@ -1,0 +1,54 @@
+﻿using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Ambev.DeveloperEvaluation.ORM.Repositories
+{
+    public class SaleRepository : ISaleRepository
+    {
+        private readonly DefaultContext _context;
+
+        public SaleRepository(DefaultContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Sale>> GetAllAsync()
+        {
+            return await _context.Sales
+                .Include(s => s.Items)
+                .ToListAsync();
+        }
+
+        public async Task<Sale> GetByIdAsync(Guid id)
+        {
+            return await _context.Sales
+                .Include(s => s.Items)
+                .FirstOrDefaultAsync(s => s.Id == id);
+        }
+
+        public async Task AddAsync(Sale sale)
+        {
+            await _context.Sales.AddAsync(sale);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Sale sale)
+        {
+            _context.Sales.Update(sale);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var sale = await _context.Sales.FindAsync(id);
+            if (sale is null) return;
+
+            _context.Sales.Remove(sale);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
@@ -3,7 +3,9 @@ using Ambev.DeveloperEvaluation.Domain.Repositories;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using System.Linq.Dynamic.Core;
 
 namespace Ambev.DeveloperEvaluation.ORM.Repositories
 {
@@ -49,6 +51,59 @@ namespace Ambev.DeveloperEvaluation.ORM.Repositories
 
             _context.Sales.Remove(sale);
             await _context.SaveChangesAsync();
+        }
+
+        public async Task<(List<Sale> Sales, int TotalItems)> GetSalesPagedAsync(
+            int page, int size, string order, string branch, DateTime? minDate, DateTime? maxDate)
+        {
+            var query = _context.Sales
+                .Include(s => s.Items)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(branch))
+                query = query.Where(s => s.Branch.Contains(branch));
+
+            if (minDate.HasValue)
+                query = query.Where(s => s.SaleDate >= minDate.Value);
+
+            if (maxDate.HasValue)
+                query = query.Where(s => s.SaleDate <= maxDate.Value);
+
+            var totalItems = await query.CountAsync();
+
+            if (!string.IsNullOrWhiteSpace(order))
+            {
+                var orderParams = order.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                bool firstOrder = true;
+
+                foreach (var param in orderParams)
+                {
+                    var trimmed = param.Trim();
+                    var parts = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var property = parts[0];
+                    var direction = parts.Length > 1 ? parts[1].ToLower() : "asc";
+
+                    var orderExpression = $"{property} {direction}";
+
+                    query = firstOrder
+                        ? query.OrderBy(orderExpression)
+                        : ((IOrderedQueryable<Sale>)query).ThenBy(orderExpression);
+
+                    firstOrder = false;
+                }
+            }
+            else
+            {
+                query = query.OrderByDescending(s => s.SaleDate);
+            }
+
+
+            var sales = await query
+                .Skip((page - 1) * size)
+                .Take(size)
+                .ToListAsync();
+
+            return (sales, totalItems);
         }
     }
 }

--- a/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
@@ -40,7 +40,30 @@ namespace Ambev.DeveloperEvaluation.ORM.Repositories
 
         public async Task UpdateAsync(Sale sale)
         {
-            _context.Sales.Update(sale);
+            var existingSale = await _context.Sales
+                .Include(s => s.Items)
+                .FirstOrDefaultAsync(s => s.Id == sale.Id);
+
+            if (existingSale == null)
+                return;
+
+            _context.SaleItems.RemoveRange(existingSale.Items);
+
+            foreach (var item in sale.Items)
+            {
+                item.Id = Guid.NewGuid();
+                item.SaleId = sale.Id;
+                _context.SaleItems.Add(item);
+            }
+
+            existingSale.SaleNumber = sale.SaleNumber;
+            existingSale.SaleDate = sale.SaleDate;
+            existingSale.CustomerId = sale.CustomerId;
+            existingSale.CustomerName = sale.CustomerName;
+            existingSale.Branch = sale.Branch;
+            existingSale.TotalAmount = sale.TotalAmount;
+            existingSale.IsCancelled = sale.IsCancelled;
+
             await _context.SaveChangesAsync();
         }
 

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/CreateSaleRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/CreateSaleRequest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CreateSale
+{
+
+    public class CreateSaleRequest
+    {
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public Guid CustomerId { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public List<CreateSaleItemRequest> Items { get; set; }
+    }
+
+    public class CreateSaleItemRequest
+    {
+        public Guid ProductId { get; set; }
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/CreateSaleRequestValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/CreateSaleRequestValidator.cs
@@ -1,0 +1,29 @@
+﻿using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CreateSale
+{
+
+    public class CreateSaleRequestValidator : AbstractValidator<CreateSaleRequest>
+    {
+        public CreateSaleRequestValidator()
+        {
+            RuleFor(s => s.SaleNumber).GreaterThan(0);
+            RuleFor(s => s.CustomerId).NotEmpty();
+            RuleFor(s => s.CustomerName).NotEmpty().MaximumLength(100);
+            RuleFor(s => s.Branch).NotEmpty().MaximumLength(50);
+
+            RuleForEach(s => s.Items).SetValidator(new CreateSaleItemRequestValidator());
+        }
+    }
+
+    public class CreateSaleItemRequestValidator : AbstractValidator<CreateSaleItemRequest>
+    {
+        public CreateSaleItemRequestValidator()
+        {
+            RuleFor(i => i.ProductId).NotEmpty();
+            RuleFor(i => i.ProductName).NotEmpty().MaximumLength(100);
+            RuleFor(i => i.Quantity).InclusiveBetween(1, 20);
+            RuleFor(i => i.UnitPrice).GreaterThan(0);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/CreateSaleResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/CreateSaleResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CreateSale
+{
+    public class CreateSaleResponse
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public decimal TotalAmount { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleRequest.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSale
+{
+    public class GetSaleRequest
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleRequestValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSale
+{
+
+    public class GetSaleRequestValidator : AbstractValidator<GetSaleRequest>
+    {
+        public GetSaleRequestValidator()
+        {
+            RuleFor(x => x.Id).NotEmpty();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleResponse.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSale
+{
+
+    public class GetSaleResponse
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public decimal TotalAmount { get; set; }
+        public bool IsCancelled { get; set; }
+        public List<GetSaleItemResponse> Items { get; set; }
+    }
+
+    public class GetSaleItemResponse
+    {
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+        public decimal TotalItemAmount { get; set; }
+        public bool IsCancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSales/GetSalesRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSales/GetSalesRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSales
+{
+    public class GetSalesRequest
+    {
+        public int Page { get; set; } = 1;
+        public int Size { get; set; } = 10;
+        public string Order { get; set; } = "SaleDate desc";
+        public string? Branch { get; set; }
+        public DateTime? MinDate { get; set; }
+        public DateTime? MaxDate { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSales/GetSalesRequestValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSales/GetSalesRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSales
+{
+    public class GetSalesRequestValidator : AbstractValidator<GetSalesRequest>
+    {
+        public GetSalesRequestValidator()
+        {
+            RuleFor(x => x.Page).GreaterThan(0);
+            RuleFor(x => x.Size).InclusiveBetween(1, 100);
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSales/GetSalesResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSales/GetSalesResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSales
+{
+    public class GetSalesResponse
+    {
+        public IEnumerable<SaleListItemResponse> Data { get; set; }
+        public int TotalItems { get; set; }
+        public int CurrentPage { get; set; }
+        public int TotalPages { get; set; }
+    }
+
+    public class SaleListItemResponse
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public decimal TotalAmount { get; set; }
+        public bool IsCancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
@@ -14,6 +14,7 @@ using Ambev.DeveloperEvaluation.Application.Sales.GetSales;
 using Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSales;
 using Ambev.DeveloperEvaluation.Application.Sales.UpdateSale;
 using Ambev.DeveloperEvaluation.WebApi.Features.Sales.UpdateSale;
+using Ambev.DeveloperEvaluation.Application.Sales.DeleteSale;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales
 {
@@ -204,6 +205,37 @@ namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales
                 Data = _mapper.Map<UpdateSaleResponse>(result)
             });
         }
+
+        /// <summary>
+        /// Deletes a sale by its ID
+        /// </summary>
+        /// <param name="id">The ID of the sale to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Success response or not found</returns>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteSale([FromRoute] Guid id, CancellationToken cancellationToken)
+        {
+            var command = new DeleteSaleCommand(id);
+            var success = await _mediator.Send(command, cancellationToken);
+
+            if (!success)
+            {
+                return NotFound(new ApiResponse
+                {
+                    Success = false,
+                    Message = "Sale not found."
+                });
+            }
+
+            return Ok(new ApiResponse
+            {
+                Success = true,
+                Message = "Sale deleted successfully."
+            });
+        }
+
 
     }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
@@ -1,0 +1,90 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
+using Ambev.DeveloperEvaluation.WebApi.Features.Sales.CreateSale;
+using AutoMapper;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Ambev.DeveloperEvaluation.WebApi.Common;
+using Ambev.DeveloperEvaluation.Common.Validation;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales
+{
+
+    /// <summary>
+    /// Controller for managing sales operations
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SalesController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+        private readonly IMapper _mapper;
+
+        /// <summary>
+        /// Initializes a new instance of SalesController
+        /// </summary>
+        /// <param name="mediator">The mediator instance</param>
+        /// <param name="mapper">The AutoMapper instance</param>
+        public SalesController(IMediator mediator, IMapper mapper)
+        {
+            _mediator = mediator;
+            _mapper = mapper;
+        }
+
+        /// <summary>
+        /// Creates a new sale
+        /// </summary>
+        /// <param name="request">The sale creation request</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created sale details</returns>
+        [HttpPost]
+        [ProducesResponseType(typeof(ApiResponseWithData<CreateSaleResponse>), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CreateSale([FromBody] CreateSaleRequest request, CancellationToken cancellationToken)
+        {
+            var validator = new CreateSaleRequestValidator();
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+
+            if (!validationResult.IsValid)
+                return BadRequest(new ApiResponse
+                {
+                    Success = false,
+                    Message = "Validation failed",
+                    Errors = validationResult.Errors
+                                 .Select(e => (ValidationErrorDetail)e)
+                });
+
+
+            var command = _mapper.Map<CreateSaleCommand>(request);
+            var result = await _mediator.Send(command, cancellationToken);
+            var response = _mapper.Map<CreateSaleResponse>(result);
+
+            return Created(string.Empty, new ApiResponseWithData<CreateSaleResponse>
+            {
+                Success = true,
+                Message = "Sale created successfully",
+                Data = response
+            });
+        }
+
+        /// <summary>
+        /// Retrieves a sale by its ID
+        /// </summary>
+        /// <param name="id">The unique identifier of the sale</param>
+        /// <returns>The sale details if found</returns>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(ApiResponseWithData<string>), StatusCodes.Status200OK)]
+        public IActionResult GetSaleById([FromRoute] Guid id)
+        {
+            // Endpoint a ser implementado
+            return Ok(new ApiResponseWithData<string>
+            {
+                Success = true,
+                Message = "Sale retrieved successfully (endpoint to be implemented)",
+                Data = $"Sale with ID {id}"
+            });
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
@@ -10,6 +10,8 @@ using Ambev.DeveloperEvaluation.WebApi.Common;
 using Ambev.DeveloperEvaluation.Common.Validation;
 using Ambev.DeveloperEvaluation.Application.Sales.GetSale;
 using Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSale;
+using Ambev.DeveloperEvaluation.Application.Sales.GetSales;
+using Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSales;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales
 {
@@ -114,5 +116,40 @@ namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales
                 Data = response
             });
         }
+
+        /// <summary>
+        /// Retrieves paginated list of sales
+        /// </summary>
+        /// <param name="request">Query parameters</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Paginated list of sales</returns>
+        [HttpGet]
+        [ProducesResponseType(typeof(ApiResponseWithData<GetSalesResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetSales([FromQuery] GetSalesRequest request, CancellationToken cancellationToken)
+        {
+            var validator = new GetSalesRequestValidator();
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+
+            if (!validationResult.IsValid)
+                return BadRequest(new ApiResponse
+                {
+                    Success = false,
+                    Message = "Validation failed",
+                    Errors = validationResult.Errors.Select(e => (ValidationErrorDetail)e)
+                });
+
+            var query = _mapper.Map<GetSalesQuery>(request);
+            var result = await _mediator.Send(query, cancellationToken);
+            var response = _mapper.Map<GetSalesResponse>(result);
+
+            return Ok(new ApiResponseWithData<GetSalesResponse>
+            {
+                Success = true,
+                Message = "Sales retrieved successfully",
+                Data = response
+            });
+        }
+
     }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSales/UpdateSaleRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSales/UpdateSaleRequest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.UpdateSale
+{
+    public class UpdateSaleRequest
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public Guid CustomerId { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public List<UpdateSaleItemRequest> Items { get; set; } = [];
+    }
+
+    public class UpdateSaleItemRequest
+    {
+        public Guid ProductId { get; set; }
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSales/UpdateSaleRequestValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSales/UpdateSaleRequestValidator.cs
@@ -1,0 +1,28 @@
+﻿using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.UpdateSale
+{
+    public class UpdateSaleRequestValidator : AbstractValidator<UpdateSaleRequest>
+    {
+        public UpdateSaleRequestValidator()
+        {
+            RuleFor(x => x.Id).NotEmpty();
+            RuleFor(x => x.SaleNumber).GreaterThan(0);
+            RuleFor(x => x.SaleDate).NotEmpty();
+            RuleFor(x => x.CustomerId).NotEmpty();
+            RuleFor(x => x.CustomerName).NotEmpty();
+            RuleFor(x => x.Branch).NotEmpty();
+
+            RuleFor(x => x.Items)
+                .NotEmpty().WithMessage("At least one item is required.");
+
+            RuleForEach(x => x.Items).ChildRules(item =>
+            {
+                item.RuleFor(i => i.ProductId).NotEmpty();
+                item.RuleFor(i => i.ProductName).NotEmpty();
+                item.RuleFor(i => i.Quantity).GreaterThan(0);
+                item.RuleFor(i => i.UnitPrice).GreaterThan(0);
+            });
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSales/UpdateSaleResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSales/UpdateSaleResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.UpdateSale
+{
+    public class UpdateSaleResponse
+    {
+        public Guid Id { get; set; }
+        public int SaleNumber { get; set; }
+        public DateTime SaleDate { get; set; }
+        public string CustomerName { get; set; }
+        public string Branch { get; set; }
+        public decimal TotalAmount { get; set; }
+        public bool IsCancelled { get; set; }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Mappings/CreateSaleRequestProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Mappings/CreateSaleRequestProfile.cs
@@ -9,11 +9,9 @@ namespace Ambev.DeveloperEvaluation.WebApi.Mappings
     {
         public CreateSaleRequestProfile()
         {
-            // WebApi → Application
             CreateMap<CreateSaleRequest, CreateSaleCommand>();
             CreateMap<CreateSaleItemRequest, CreateSaleItemDto>();
 
-            // Application → WebApi
             CreateMap<CreateSaleResult, CreateSaleResponse>();
         }
     }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Mappings/CreateSaleRequestProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Mappings/CreateSaleRequestProfile.cs
@@ -1,0 +1,20 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
+using Ambev.DeveloperEvaluation.WebApi.Features.Sales.CreateSale;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Mappings
+{
+
+    public class CreateSaleRequestProfile : Profile
+    {
+        public CreateSaleRequestProfile()
+        {
+            // WebApi → Application
+            CreateMap<CreateSaleRequest, CreateSaleCommand>();
+            CreateMap<CreateSaleItemRequest, CreateSaleItemDto>();
+
+            // Application → WebApi
+            CreateMap<CreateSaleResult, CreateSaleResponse>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Mappings/GetSaleRequestProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Mappings/GetSaleRequestProfile.cs
@@ -1,0 +1,17 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.GetSale;
+using Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSale;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Mappings
+{
+
+    public class GetSaleRequestProfile : Profile
+    {
+        public GetSaleRequestProfile()
+        {
+            CreateMap<GetSaleRequest, GetSaleQuery>();
+            CreateMap<GetSaleResult, GetSaleResponse>();
+            CreateMap<GetSaleItemDto, GetSaleItemResponse>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Mappings/GetSalesRequestProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Mappings/GetSalesRequestProfile.cs
@@ -1,0 +1,16 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.GetSales;
+using Ambev.DeveloperEvaluation.WebApi.Features.Sales.GetSales;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Mappings
+{
+    public class GetSalesRequestProfile : Profile
+    {
+        public GetSalesRequestProfile()
+        {
+            CreateMap<GetSalesRequest, GetSalesQuery>();
+            CreateMap<GetSalesResult, GetSalesResponse>();
+            CreateMap<SaleListItemDto, SaleListItemResponse>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Mappings/UpdateSaleRequestProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Mappings/UpdateSaleRequestProfile.cs
@@ -1,0 +1,17 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.UpdateSale;
+using Ambev.DeveloperEvaluation.WebApi.Features.Sales.UpdateSale;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Mappings
+{
+    public class UpdateSaleRequestProfile : Profile
+    {
+        public UpdateSaleRequestProfile()
+        {
+            CreateMap<UpdateSaleRequest, UpdateSaleCommand>();
+            CreateMap<UpdateSaleItemRequest, UpdateSaleItemDto>();
+
+            CreateMap<UpdateSaleResult, UpdateSaleResponse>();
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
@@ -9,6 +9,7 @@ using Ambev.DeveloperEvaluation.WebApi.Middleware;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
+using System.Globalization;
 
 namespace Ambev.DeveloperEvaluation.WebApi;
 
@@ -18,6 +19,10 @@ public class Program
     {
         try
         {
+            var cultureInfo = new CultureInfo("en-US");
+            CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+            CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
+
             Log.Information("Starting web application");
 
             WebApplicationBuilder builder = WebApplication.CreateBuilder(args);

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/CreateSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/CreateSaleHandlerTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using NSubstitute;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales
+{
+    public class CreateSaleHandlerTests
+    {
+        private readonly ISaleRepository _saleRepository;
+        private readonly IMapper _mapper;
+        private readonly CreateSaleHandler _handler;
+
+        public CreateSaleHandlerTests()
+        {
+            _saleRepository = Substitute.For<ISaleRepository>();
+            _mapper = Substitute.For<IMapper>();
+            _handler = new CreateSaleHandler(_saleRepository, _mapper);
+        }
+
+        [Fact]
+        public async Task Handle_Should_CreateSaleSuccessfully()
+        {
+            // Arrange
+            var command = new CreateSaleCommand
+            {
+                SaleNumber = 1,
+                SaleDate = DateTime.Now,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Customer Test",
+                Branch = "Branch Test",
+                Items = new List<CreateSaleItemDto>
+            {
+                new() { ProductId = Guid.NewGuid(), ProductName = "Product 1", Quantity = 3, UnitPrice = 10 },
+                new() { ProductId = Guid.NewGuid(), ProductName = "Product 2", Quantity = 18, UnitPrice = 25 }
+            }
+            };
+
+            var sale = new Sale
+            {
+                Id = Guid.NewGuid(),
+                SaleNumber = command.SaleNumber,
+                CustomerName = command.CustomerName,
+                Items = command.Items.Select(item => new SaleItem
+                {
+                    ProductId = item.ProductId,
+                    ProductName = item.ProductName,
+                    Quantity = item.Quantity,
+                    UnitPrice = item.UnitPrice
+                }).ToList()
+            };
+
+            _mapper.Map<Sale>(command).Returns(sale);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await _saleRepository.Received(1).AddAsync(Arg.Is<Sale>(s =>
+                s.SaleNumber == command.SaleNumber &&
+                s.CustomerName == command.CustomerName &&
+                s.Items.Count == command.Items.Count &&
+                s.TotalAmount > 0
+            ));
+
+            Assert.NotNull(result);
+            Assert.Equal(sale.Id, result.Id);
+            Assert.Equal(sale.SaleNumber, result.SaleNumber);
+            Assert.Equal(sale.TotalAmount, result.TotalAmount);
+        }
+    }
+}

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/DeleteSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/DeleteSaleHandlerTests.cs
@@ -1,0 +1,55 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.DeleteSale;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using NSubstitute;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales
+{
+
+    public class DeleteSaleHandlerTests
+    {
+        private readonly ISaleRepository _saleRepository = Substitute.For<ISaleRepository>();
+
+        [Fact]
+        public async Task Handle_Should_DeleteSale_WhenSaleExists()
+        {
+            // Arrange
+            var saleId = Guid.NewGuid();
+            var existingSale = new Sale { Id = saleId };
+
+            _saleRepository.GetByIdAsync(saleId).Returns(existingSale);
+
+            var command = new DeleteSaleCommand(saleId);
+            var handler = new DeleteSaleHandler(_saleRepository);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.True(result);
+            await _saleRepository.Received(1).DeleteAsync(saleId);
+        }
+
+        [Fact]
+        public async Task Handle_Should_ReturnFalse_WhenSaleDoesNotExist()
+        {
+            // Arrange
+            var saleId = Guid.NewGuid();
+            _saleRepository.GetByIdAsync(saleId).Returns((Sale)null);
+
+            var command = new DeleteSaleCommand(saleId);
+            var handler = new DeleteSaleHandler(_saleRepository);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result);
+            await _saleRepository.DidNotReceive().DeleteAsync(Arg.Any<Guid>());
+        }
+    }
+}

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/GetSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/GetSaleHandlerTests.cs
@@ -1,0 +1,96 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.GetSale;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using Bogus;
+using NSubstitute;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales
+{
+    public class GetSaleHandlerTests
+    {
+        private readonly ISaleRepository _saleRepository;
+        private readonly IMapper _mapper;
+        private readonly GetSaleHandler _handler;
+
+        public GetSaleHandlerTests()
+        {
+            _saleRepository = Substitute.For<ISaleRepository>();
+
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Sale, GetSaleResult>();
+                cfg.CreateMap<SaleItem, GetSaleItemDto>();
+            });
+            _mapper = config.CreateMapper();
+
+            _handler = new GetSaleHandler(_saleRepository, _mapper);
+        }
+
+        [Fact]
+        public async Task Handle_Should_ReturnSale_WhenSaleExists()
+        {
+            // Arrange
+            var sale = GenerateFakeSale();
+            _saleRepository.GetByIdAsync(sale.Id).Returns(sale);
+
+            var query = new GetSaleQuery { Id = sale.Id };
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(sale.SaleNumber, result.SaleNumber);
+            Assert.Equal(sale.CustomerName, result.CustomerName);
+            Assert.Equal(sale.Items.Count, result.Items.Count);
+        }
+
+        [Fact]
+        public async Task Handle_Should_ReturnNull_WhenSaleDoesNotExist()
+        {
+            // Arrange
+            var query = new GetSaleQuery { Id = Guid.NewGuid() };
+            _saleRepository.GetByIdAsync(query.Id).Returns((Sale)null);
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        private Sale GenerateFakeSale()
+        {
+            var faker = new Faker("pt_BR");
+            var saleId = Guid.NewGuid();
+
+            return new Sale
+            {
+                Id = saleId,
+                SaleNumber = faker.Random.Int(1000, 9999),
+                SaleDate = faker.Date.Recent(),
+                CustomerId = Guid.NewGuid(),
+                CustomerName = faker.Name.FullName(),
+                Branch = faker.Company.CompanyName(),
+                TotalAmount = faker.Random.Decimal(100, 1000),
+                IsCancelled = false,
+                Items = new List<SaleItem>
+                {
+                    new SaleItem
+                    {
+                        Id = Guid.NewGuid(),
+                        SaleId = saleId,
+                        ProductId = Guid.NewGuid(),
+                        ProductName = faker.Commerce.ProductName(),
+                        Quantity = 3,
+                        UnitPrice = 50,
+                        TotalItemAmount = 150,
+                        IsCancelled = false
+                    }
+                }
+            };
+        }
+    }
+}

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/GetSalesHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/GetSalesHandlerTests.cs
@@ -1,0 +1,80 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.GetSales;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using Bogus;
+using NSubstitute;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales;
+
+public class GetSalesHandlerTests
+{
+    private readonly ISaleRepository _saleRepository;
+    private readonly IMapper _mapper;
+    private readonly GetSalesHandler _handler;
+
+    public GetSalesHandlerTests()
+    {
+        _saleRepository = Substitute.For<ISaleRepository>();
+
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Sale, SaleListItemDto>();
+        });
+        _mapper = config.CreateMapper();
+
+        _handler = new GetSalesHandler(_saleRepository, _mapper);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnPagedSalesSuccessfully()
+    {
+        // Arrange
+        var sales = GenerateFakeSales(5);
+        _saleRepository.GetSalesPagedAsync(1, 10, "SaleDate desc", null, null, null)
+            .Returns((sales, sales.Count));
+
+        var query = new GetSalesQuery
+        {
+            Page = 1,
+            Size = 10,
+            Order = "SaleDate desc"
+        };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(sales.Count, result.TotalItems);
+        Assert.Equal(sales.Count, result.Data.Count());
+        Assert.Equal(1, result.CurrentPage);
+        Assert.Equal(1, result.TotalPages);
+    }
+
+    private List<Sale> GenerateFakeSales(int count)
+    {
+        var faker = new Faker("pt_BR");
+        var sales = new List<Sale>();
+
+        for (int i = 0; i < count; i++)
+        {
+            var saleId = Guid.NewGuid();
+            sales.Add(new Sale
+            {
+                Id = saleId,
+                SaleNumber = faker.Random.Int(1000, 9999),
+                SaleDate = faker.Date.Recent(),
+                CustomerId = Guid.NewGuid(),
+                CustomerName = faker.Name.FullName(),
+                Branch = faker.Company.CompanyName(),
+                TotalAmount = faker.Random.Decimal(100, 1000),
+                IsCancelled = false,
+                Items = new List<SaleItem>()
+            });
+        }
+
+        return sales;
+    }
+}

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/UpdateSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/Sales/UpdateSaleHandlerTests.cs
@@ -1,0 +1,242 @@
+﻿using Ambev.DeveloperEvaluation.Application.Sales.UpdateSale;
+using Ambev.DeveloperEvaluation.Common.Exceptions;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using Bogus;
+using NSubstitute;
+using Xunit;
+
+namespace Ambev.DeveloperEvaluation.Unit.Application.Sales
+{
+    public class UpdateSaleHandlerTests
+    {
+        private readonly ISaleRepository _saleRepository = Substitute.For<ISaleRepository>();
+        private readonly IMapper _mapper;
+
+        public UpdateSaleHandlerTests()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Sale, UpdateSaleResult>();
+            });
+
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public async Task Handle_Should_UpdateSaleSuccessfully()
+        {
+            // Arrange
+            var saleId = Guid.NewGuid();
+            var existingSale = new Sale
+            {
+                Id = saleId,
+                SaleNumber = 1001,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Test Customer",
+                Branch = "Branch A",
+                Items = new List<SaleItem>()
+            };
+
+            _saleRepository.GetByIdAsync(saleId).Returns(existingSale);
+
+            var command = new UpdateSaleCommand
+            {
+                Id = saleId,
+                SaleNumber = 2002,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Updated Customer",
+                Branch = "Branch B",
+                Items = new List<UpdateSaleItemDto>
+            {
+                new UpdateSaleItemDto
+                {
+                    ProductId = Guid.NewGuid(),
+                    ProductName = "Product A",
+                    Quantity = 5,
+                    UnitPrice = 10
+                }
+            }
+            };
+
+            var handler = new UpdateSaleHandler(_saleRepository, _mapper);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(command.SaleNumber, result.SaleNumber);
+            Assert.Equal(command.CustomerName, result.CustomerName);
+            Assert.Equal(command.Branch, result.Branch);
+            Assert.True(result.TotalAmount > 0);
+
+            await _saleRepository.Received(1).UpdateAsync(Arg.Is<Sale>(s =>
+                s.SaleNumber == command.SaleNumber &&
+                s.CustomerName == command.CustomerName &&
+                s.Items.Count == 1 &&
+                s.TotalAmount > 0));
+        }
+
+        [Fact]
+        public async Task Handle_Should_ThrowBusinessException_WhenQuantityExceedsLimit()
+        {
+            // Arrange
+            var saleId = Guid.NewGuid();
+            var existingSale = new Sale
+            {
+                Id = saleId,
+                SaleNumber = 1001,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Test Customer",
+                Branch = "Branch A",
+                Items = new List<SaleItem>()
+            };
+
+            _saleRepository.GetByIdAsync(saleId).Returns(existingSale);
+
+            var command = new UpdateSaleCommand
+            {
+                Id = saleId,
+                SaleNumber = 2002,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Updated Customer",
+                Branch = "Branch B",
+                Items = new List<UpdateSaleItemDto>
+            {
+                new UpdateSaleItemDto
+                {
+                    ProductId = Guid.NewGuid(),
+                    ProductName = "Product B",
+                    Quantity = 21,
+                    UnitPrice = 10
+                }
+            }
+            };
+
+            var handler = new UpdateSaleHandler(_saleRepository, _mapper);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<BusinessException>(() => handler.Handle(command, CancellationToken.None));
+            await _saleRepository.DidNotReceive().UpdateAsync(Arg.Any<Sale>());
+        }
+
+        [Fact]
+        public async Task Handle_Should_CalculateNoDiscount_WhenQuantityIsLessThan4()
+        {
+            // Arrange
+            var saleId = Guid.NewGuid();
+            var existingSale = new Sale { Id = saleId, Items = new List<SaleItem>() };
+            _saleRepository.GetByIdAsync(saleId).Returns(existingSale);
+
+            var command = new UpdateSaleCommand
+            {
+                Id = saleId,
+                SaleNumber = 3001,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Customer",
+                Branch = "Branch X",
+                Items = new List<UpdateSaleItemDto>
+        {
+            new UpdateSaleItemDto
+            {
+                ProductId = Guid.NewGuid(),
+                ProductName = "Product 1",
+                Quantity = 3,
+                UnitPrice = 10
+            }
+        }
+            };
+
+            var handler = new UpdateSaleHandler(_saleRepository, _mapper);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            var expectedTotal = 3 * 10;
+            Assert.Equal(expectedTotal, result.TotalAmount);
+        }
+
+        [Fact]
+        public async Task Handle_Should_Apply10PercentDiscount_WhenQuantityBetween4And9()
+        {
+            var saleId = Guid.NewGuid();
+            var existingSale = new Sale { Id = saleId, Items = new List<SaleItem>() };
+            _saleRepository.GetByIdAsync(saleId).Returns(existingSale);
+
+            var command = new UpdateSaleCommand
+            {
+                Id = saleId,
+                SaleNumber = 3002,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Customer",
+                Branch = "Branch X",
+                Items = new List<UpdateSaleItemDto>
+        {
+            new UpdateSaleItemDto
+            {
+                ProductId = Guid.NewGuid(),
+                ProductName = "Product 2",
+                Quantity = 5,
+                UnitPrice = 20
+            }
+        }
+            };
+
+            var handler = new UpdateSaleHandler(_saleRepository, _mapper);
+
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            var totalBeforeDiscount = 5 * 20;
+            var expectedTotal = totalBeforeDiscount * 0.90m;
+
+            Assert.Equal(expectedTotal, result.TotalAmount);
+        }
+
+        [Fact]
+        public async Task Handle_Should_Apply20PercentDiscount_WhenQuantityBetween10And20()
+        {
+            var saleId = Guid.NewGuid();
+            var existingSale = new Sale { Id = saleId, Items = new List<SaleItem>() };
+            _saleRepository.GetByIdAsync(saleId).Returns(existingSale);
+
+            var command = new UpdateSaleCommand
+            {
+                Id = saleId,
+                SaleNumber = 3003,
+                SaleDate = DateTime.UtcNow,
+                CustomerId = Guid.NewGuid(),
+                CustomerName = "Customer",
+                Branch = "Branch X",
+                Items = new List<UpdateSaleItemDto>
+        {
+            new UpdateSaleItemDto
+            {
+                ProductId = Guid.NewGuid(),
+                ProductName = "Product 3",
+                Quantity = 15,
+                UnitPrice = 30
+            }
+        }
+            };
+
+            var handler = new UpdateSaleHandler(_saleRepository, _mapper);
+
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            var totalBeforeDiscount = 15 * 30;
+            var expectedTotal = totalBeforeDiscount * 0.80m;
+
+            Assert.Equal(expectedTotal, result.TotalAmount);
+        }
+
+    }
+}


### PR DESCRIPTION
Este Pull Request entrega a implementação completa do CRUD de vendas, incluindo:

- Criação de vendas (POST /sales)
- Consulta individual e paginada de vendas (GET /sales/{id}, GET /sales)
- Atualização de vendas com regras de negócio aplicadas (PUT /sales/{id})
- Exclusão de vendas (DELETE /sales/{id})
- Aplicação de regras de desconto baseadas em quantidade de itens
- Tratamento de erros com BusinessException e mensagens padronizadas em inglês
- Testes unitários cobrindo todos os cenários das regras de negócio
- Commits organizados e estrutura de projeto conforme padrão DDD