### PR TITLE
fix: corrige mapeamento de autenticação e atualiza documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ This API fully implements the required functionalities:
 - [x] Data validation with standardized English messages
 - [x] Domain events implemented and logged to the console (SaleCreated, SaleModified, SaleCancelled)
 
+### Authentication
+
+JWT authentication is fully functional in the project.
+
+- The endpoint `/auth` returns a token after validating user credentials
+- To protect any route (e.g., `/sales`), simply add the `[Authorize]` attribute
+
+> Note: An AutoMapper configuration issue was found in the original project template and has been fixed to ensure correct JWT token generation.
+
 ## Features
 - Create, retrieve, update, and delete sales records
 - Business rules applied on sales items:

--- a/readme-ptbr.md
+++ b/readme-ptbr.md
@@ -13,6 +13,15 @@ A API implementa integralmente as funcionalidades requeridas:
 - [x] Validação de dados com mensagens padronizadas em inglês
 - [x] Eventos de domínio implementados e logados no console (SaleCreated, SaleModified, SaleCancelled)
 
+### Autenticação
+
+A autenticação JWT está funcional no projeto.
+
+- O endpoint `/auth` retorna um token após validação das credenciais do usuário
+- Para proteger rotas (ex: `/sales`), basta adicionar o atributo `[Authorize]`
+
+> Obs: Foi identificado um problema de configuração do AutoMapper no template original, que foi corrigido para garantir a geração correta do token JWT.
+
 ## Funcionalidades
 - Criar, consultar, atualizar e excluir registros de vendas
 - Regras de negócio aplicadas aos itens da venda:

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Auth/AuthenticateUserFeature/AuthenticateUserProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Auth/AuthenticateUserFeature/AuthenticateUserProfile.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Application.Auth.AuthenticateUser;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Auth.AuthenticateUserFeature;
 
@@ -13,6 +14,10 @@ public sealed class AuthenticateUserProfile : Profile
     /// </summary>
     public AuthenticateUserProfile()
     {
+        CreateMap<AuthenticateUserRequest, AuthenticateUserCommand>();
+
+        CreateMap<AuthenticateUserResult, AuthenticateUserResponse>();
+
         CreateMap<User, AuthenticateUserResponse>()
             .ForMember(dest => dest.Token, opt => opt.Ignore())
             .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()));


### PR DESCRIPTION
## Correção de mapeamento AutoMapper

Corrige problema encontrado no template original do projeto que impedia o mapeamento de `AuthenticateUserRequest` para `AuthenticateUserCommand`.

- Adicionados os `CreateMap` necessários ao `AuthenticateUserProfile`
- Corrigido o fluxo de autenticação no endpoint `/auth`, agora funcional com retorno de token JWT

## Atualização da documentação

- Atualização dos arquivos `README.md` e `README-ptbr.md` com:
  - Instruções sobre autenticação
  - Explicação sobre proteção de rotas usando `[Authorize]`
  - Nota esclarecendo que o problema corrigido já estava presente no template original
